### PR TITLE
Show notification badge for notification inbox screens

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -43,14 +43,6 @@
   text-align: center;
 }
 
-.notification-badge {
-  display: none;
-}
-
-[data-notification-inbox-1-0-0-id] .notification-unread .notification-badge {
-  display: block;
-}
-
 [data-notification-inbox-1-0-0-id] .no-notifications,
 [data-notification-inbox-1-0-0-id] .notifications-error {
   margin-bottom: 40px;


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/4025

> [...] the notification badge doesn't appear if you're on the screen where the notification inbox is.
>
> Having said that, this logic was implemented months ago, and I no longer think it makes sense. There shouldn't be any problem with the badges appear on the screen where the inbox is.