### PR TITLE
Sets notification title with a better default line height

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -65,6 +65,7 @@
   position: relative;
   margin: 10px 0;
   font-weight: 600;
+  line-height: 1.3;
 }
 
 [data-notification-inbox-1-0-0-id] .notification .description {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/290733/55797910-8650a500-5ac5-11e9-96be-057eda63e578.png)

instead of

![image](https://user-images.githubusercontent.com/290733/55797924-8c468600-5ac5-11e9-8659-d3e7a74c2dd7.png)
