### PR TITLE
Adds demo mode to notification inbox and fixes issues with "load more" button

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -30,10 +30,6 @@
   cursor: pointer;
 }
 
-.platform-web [data-notification-inbox-1-0-0-id] .notifications-toolbar [data-settings] {
-  display: none;
-}
-
 [data-notification-inbox-1-0-0-id] .notifications .notifications-new {
   position: relative;
   width: 100%;

--- a/js/build.js
+++ b/js/build.js
@@ -9,13 +9,15 @@ Fliplet.Widget.instance('notification-inbox-1-0-0', function (data) {
   // Sample implementation to initialize the widget
   var inbox = new NotificationInbox(element, data);
 
-  if (!Fliplet.Registry.get('fliplet-widget-notifications:1.0:core')) {
-    // Notifications add-on isn't available
-    // Initialize inbox in demo mode
-    inbox.init({
-      mode: 'demo'
-    });
-  }
+  Fliplet().then(function () {
+    if (!Fliplet.Registry.get('fliplet-widget-notifications:1.0:core')) {
+      // Notifications add-on isn't available
+      // Initialize inbox in demo mode
+      inbox.init({
+        mode: 'demo'
+      });
+    }
+  });
 
   Fliplet.Hooks.on('beforeNotificationsInit', function (appComponentData, options) {
     options.clearNewCountOnUpdate = true;

--- a/js/build.js
+++ b/js/build.js
@@ -8,9 +8,21 @@ Fliplet.Widget.instance('notification-inbox-1-0-0', function (data) {
 
   // Sample implementation to initialize the widget
   var inbox = new NotificationInbox(element, data);
+
+  if (!Fliplet.Registry.get('fliplet-widget-notifications:1.0:core')) {
+    // Notifications add-on isn't available
+    // Initialize inbox in demo mode
+    inbox.init({
+      mode: 'demo'
+    });
+  }
+
   Fliplet.Hooks.on('beforeNotificationsInit', function (appComponentData, options) {
+    options.clearNewCountOnUpdate = true;
+    options.startCheckingUpdates = true;
+
     // Initialize Notification Inbox component
-    inbox.init(options);
+    inbox.init();
   });
 });
 

--- a/js/libs.js
+++ b/js/libs.js
@@ -123,6 +123,10 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
       $loadMore = $([]);
     }
 
+    if (notification.status === 'draft') {
+      return;
+    }
+
     if (notification.isDeleted) {
       deleteNotification(notification);
     } else if (notification.isUpdate) {

--- a/js/libs.js
+++ b/js/libs.js
@@ -6,8 +6,9 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
   var $notifications = $container.find('.notifications');
 
   var notifications = [];
-  var $loadMore;
+  var $loadMore = $([]);
   var appNotifications;
+  var isLastNotificationLoaded = false;
 
   function isUnread(n) {
     return !n.readStatus;
@@ -58,7 +59,7 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
       $notifications.find('.notification').eq(index).before(html);
     }
 
-    if (options.addLoadMore && !$loadMore) {
+    if (options.addLoadMore && !$loadMore.length && !isLastNotificationLoaded) {
       $loadMore = $(Fliplet.Widget.Templates['templates.loadMore']());
       $notifications.after($loadMore);
     }
@@ -112,6 +113,12 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
   }
 
   function processNotification(notification) {
+    if (notification.isLastNotification) {
+      isLastNotificationLoaded = true;
+      $loadMore.remove();
+      $loadMore = $([]);
+    }
+
     if (notification.isDeleted) {
       deleteNotification(notification);
     } else if (notification.isUpdate) {
@@ -213,8 +220,9 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
       });
 
       if (!results.entries.length) {
+        isLastNotificationLoaded = true;
         $loadMore.remove();
-        $loadMore = null;
+        $loadMore = $([]);
         return;
       }
 

--- a/js/libs.js
+++ b/js/libs.js
@@ -288,7 +288,7 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
       }
 
       if (!_.filter(notifications, function (notification) {
-        return !notification.deletedAt || notification.status === 'draft';
+        return !notification.deletedAt && notification.status !== 'draft';
       }).length) {
         if (Fliplet.App.isPreview(true)) {
           // The app is running in Fliplet Viewer or Fliplet Studio

--- a/js/libs.js
+++ b/js/libs.js
@@ -63,6 +63,8 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
       $loadMore = $(Fliplet.Widget.Templates['templates.loadMore']());
       $notifications.after($loadMore);
     }
+
+    Fliplet.Studio.emit('get-selected-widget');
   }
 
   function updateNotification(notification) {
@@ -76,6 +78,7 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
 
     notifications[index] = notification;
     $('[data-notification-id="' + notification.id + '"]').replaceWith(html);
+    Fliplet.Studio.emit('get-selected-widget');
   }
 
   function deleteNotification(notification, options) {
@@ -90,6 +93,7 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
       return n.id === notification.id;
     });
     $('[data-notification-id="' + notification.id + '"]').remove();
+    Fliplet.Studio.emit('get-selected-widget');
 
     if (!notifications.length) {
       noNotificationsFound();
@@ -252,6 +256,7 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
   function noNotificationsFound() {
     $('.notifications').html(Fliplet.Widget.Templates['templates.noNotifications']());
     updateUnreadCount(0);
+    Fliplet.Studio.emit('get-selected-widget');
   }
 
   function attachObservers() {
@@ -329,6 +334,8 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
   }
 
   function init(options) {
+    Fliplet.Studio.emit('get-selected-widget');
+
     moment.updateLocale('en', {
       calendar : {
         sameElse: 'MMMM Do YYYY'

--- a/js/libs.js
+++ b/js/libs.js
@@ -275,7 +275,7 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
       }
 
       if (!_.filter(notifications, { deletedAt: null }).length) {
-        if (Fliplet.Navigate.get('preview')) {
+        if (Fliplet.Env.get('preview')) {
           initDemo();
           return;
         }


### PR DESCRIPTION
- Fixes an issue where the **Load more** button is displayed even when there's no more to load (https://github.com/Fliplet/fliplet-studio/issues/4694)
- Adds demo notifications for the 2 following scenarios (see sample below):
    - The Notifications app add-on isn't available
    - There is no notification available for the user and the app is viewed in Studio or Viewer
- Developers can use the `beforeShowDemoNotifications` hook to customise demo mode notifications
- Draft notifications are no longer appearing

![image](https://user-images.githubusercontent.com/290733/75190854-1bde3d00-5749-11ea-92ba-d8d7efc17a15.png)
