### PR TITLE
Now save button is not disappearing after opening Notifications overlay

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -15,6 +15,13 @@ function attachObservers() {
   // Update Studio interface labels
   $(window).on('resize', Fliplet.Widget.autosize);
 
+  // Toggle save button after notifications overlay closes
+  window.addEventListener('message', function(event) {
+    if (event.data.event === 'overlay-close') {
+      Fliplet.Widget.resetSaveButtonLabel();
+    }
+  });
+
   // Fired from Fliplet Studio when the external save button is clicked
   Fliplet.Widget.onSaveRequest(function () {
     return saveWidget();


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6212

## Description
Added Fliplet.Widget.resetSaveButtonLabel(); after closing the overlay.

## Screenshots/screencasts
![notification-inbox](https://user-images.githubusercontent.com/52824207/79353870-517ef580-7f44-11ea-9f0c-e644f8d1f7b0.gif)

## Backward compatibility
This change is fully backward compatible.

## Reviewers 
@upplabs-alex-levchenko @YaroslavOvdii