### PR TITLE
[Fix] Check existing notifications before adding notifications

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -40,7 +40,12 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function (element, data) {
     options = options || {};
 
     var html = getNotificationRender(notification);
-    var index = -1;
+    var index = _.findIndex(notifications, { id: notification.id });
+
+    if (index > -1) {
+      updateNotification(notification);
+      return;
+    }
 
     notifications.push(notification);
     notifications = _.orderBy(notifications, ['orderAt'], ['desc']);


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/6317

We're unsure why the bug is occurring. In case this is caused by the frontend incorrectly caching/processing/streaming the same notification more than once, this change should prevent the same notification being added twice.