### PR TITLE
ID-850 [Fix] Overwrite cache when fetch requests are forced

### DIFF
--- a/js/app/libs.js
+++ b/js/app/libs.js
@@ -126,8 +126,6 @@ Fliplet.Registry.set('notification-inbox:1.0:app:core', function(data) {
    * @returns {Promise} The promise resolves when the session data is updated, taking throttling into consideration
    */
   function setAppNotificationSeenAt(options) {
-    var forceFetch;
-
     options = options || {};
 
     // Default to current timestamp in seconds
@@ -135,16 +133,11 @@ Fliplet.Registry.set('notification-inbox:1.0:app:core', function(data) {
       options.seenAt = Math.floor(Date.now() / 1000);
     }
 
-    // Update session immediately
-    if (options.force) {
-      forceFetch = true;
-    }
-
     // Update appNotificationsSeenAt (throttled at 60 seconds)
     return Fliplet.Cache.get({
       expire: 60,
       key: 'appNotificationsSeenAt',
-      forceBackgroundUpdate: forceFetch
+      forceBackgroundUpdate: options.force
     }, function updateSession() {
       return Fliplet.Session.set(
         { appNotificationsSeenAt: options.seenAt },

--- a/js/app/libs.js
+++ b/js/app/libs.js
@@ -121,17 +121,12 @@ Fliplet.Registry.set('notification-inbox:1.0:app:core', function(data) {
   /**
    * Updates the session with the latest timestamp that the notifications were seen
    * @param {Object} options - A mapping of options for the function
-   * @param {Number} options.seenAt - Timestamp in seconds. Defaults to current timestamp if falsey
+   * @param {Number} options.seenAt - UNIX timestamp in seconds. Defaults to current timestamp if falsy
    * @param {Boolean} options.force - If true, throttling is disabled
    * @returns {Promise} The promise resolves when the session data is updated, taking throttling into consideration
    */
   function setAppNotificationSeenAt(options) {
-    function updateSession() {
-      return Fliplet.Session.set(
-        { appNotificationsSeenAt: options.seenAt },
-        { required: true }
-      );
-    }
+    var forceFetch;
 
     options = options || {};
 
@@ -142,17 +137,20 @@ Fliplet.Registry.set('notification-inbox:1.0:app:core', function(data) {
 
     // Update session immediately
     if (options.force) {
-      return updateSession();
+      forceFetch = true;
     }
 
     // Update appNotificationsSeenAt (throttled at 60 seconds)
-    return Fliplet.Cache.get(
-      {
-        expire: 60,
-        key: 'appNotificationsSeenAt'
-      },
-      updateSession
-    );
+    return Fliplet.Cache.get({
+      expire: 60,
+      key: 'appNotificationsSeenAt',
+      forceBackgroundUpdate: forceFetch
+    }, function updateSession() {
+      return Fliplet.Session.set(
+        { appNotificationsSeenAt: options.seenAt },
+        { required: true }
+      );
+    });
   }
 
   function broadcastCountUpdates() {
@@ -178,29 +176,30 @@ Fliplet.Registry.set('notification-inbox:1.0:app:core', function(data) {
     lastClearedAt = lastClearedAt || now;
     options = options || {};
 
-    function fetchCounts() {
-      var getNewCount = pageHasInbox
-        ? Promise.resolve(0)
-        // TODO Update to use instance.new.count()
-        : instance.unread.count({ createdAt: { $gt: lastClearedAt } });
-
-      return Promise.all([
-        getNewCount,
-        instance.unread.count()
-      ]);
-    }
-
     return Fliplet.Navigator.Notifications.getAppBadge().then(function(badgeNumber) {
+      var forceFetch;
+
       // App badge number has changed. Get the latest counts immediately.
       if ((typeof badgeNumber === 'number' && badgeNumber !== storage[countProp]) || options.force) {
-        return fetchCounts();
+        forceFetch = true;
       }
 
       // Get notification counts (throttled at 20 seconds)
       return Fliplet.Cache.get({
         expire: 20,
-        key: 'appNotificationCount'
-      }, fetchCounts);
+        key: 'appNotificationCount',
+        forceBackgroundUpdate: forceFetch
+      }, function fetchCounts() {
+        var getNewCount = pageHasInbox
+          ? Promise.resolve(0)
+          // TODO Update to use instance.new.count()
+          : instance.unread.count({ createdAt: { $gt: lastClearedAt } });
+
+        return Promise.all([
+          getNewCount,
+          instance.unread.count()
+        ]);
+      });
     });
   }
 

--- a/js/libs.js
+++ b/js/libs.js
@@ -319,19 +319,9 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function(element, data) {
       });
     }
 
-    Fliplet.Hooks.on('afterNotificationsInit', function(instance, counts) {
+    Fliplet.Hooks.on('afterNotificationsInit', function(instance) {
       // Notifications have loaded
       appNotifications = instance;
-
-      var notificationsBadgeType = Fliplet.Env.get('appSettings').notificationsBadgeType;
-      var forceUpdate = notificationsBadgeType !== 'unread' && counts.newCount > 0;
-
-      // Update session with the timestamp the notifications were last seen
-      // Ignore throttling if the notification badge count is based on new notifications
-      // and the count has just been reset
-      instance.setAppNotificationSeenAt({
-        force: forceUpdate
-      });
     });
 
     $container


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-850

The forced fetch functions were being run in isolation from the `Fliplet.Cache.get()` functions, which means when this happens, the cache isn't updated.

This PR updates the logic so that the cache is correctly updated when the requests are forced.