### PR TITLE
OD-626 [Fix] Localize date, time and number for notifications

### DIFF
--- a/js/build.templates.js
+++ b/js/build.templates.js
@@ -11,7 +11,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.noNotifications"] = Handlebars
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.notification"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<div class=\"notification {{#if readStatus}}notification-read{{else}}notification-unread{{/if}}{{#if hasLink}} notification-linked{{/if}}\" data-notification-id=\"{{id}}\" data-notification-status=\"{{status}}\">\r\n  <div class=\"subtitle\">{{TD orderAt calendar=\"null\"}}</div>\r\n  {{#if data.title}}<h2 class=\"title\">{{data.title}}</h2>{{/if}}\r\n  {{#if data.message}}<div class=\"description\">\r\n    <p>{{data.message}}</p>\r\n  </div>{{/if}}\r\n  {{#unless readStatus}}<div class=\"notification-badge\"></div>{{/unless}}\r\n</div>";
+    return "<div class=\"notification {{#if readStatus}}notification-read{{else}}notification-unread{{/if}}{{#if hasLink}} notification-linked{{/if}}\" data-notification-id=\"{{id}}\" data-notification-status=\"{{status}}\">\r\n  <div class=\"subtitle\">{{TD orderAt format=\"fromNow\"}}</div>\r\n  {{#if data.title}}<h2 class=\"title\">{{data.title}}</h2>{{/if}}\r\n  {{#if data.message}}<div class=\"description\">\r\n    <p>{{data.message}}</p>\r\n  </div>{{/if}}\r\n  {{#unless readStatus}}<div class=\"notification-badge\"></div>{{/unless}}\r\n</div>\r\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.notificationsError"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/templates/notification.build.hbs
+++ b/templates/notification.build.hbs
@@ -1,5 +1,5 @@
 <div class="notification \{{#if readStatus}}notification-read\{{else}}notification-unread\{{/if}}\{{#if hasLink}} notification-linked\{{/if}}" data-notification-id="\{{id}}" data-notification-status="\{{status}}">
-  <div class="subtitle">\{{TD orderAt calendar="null"}}</div>
+  <div class="subtitle">\{{TD orderAt format="fromNow"}}</div>
   \{{#if data.title}}<h2 class="title">\{{data.title}}</h2>\{{/if}}
   \{{#if data.message}}<div class="description">
     <p>\{{data.message}}</p>


### PR DESCRIPTION
@romanyosyfiv

OD-626 https://weboo.atlassian.net/browse/OD-626

## Description
The date, time, and number of unread notifications that have been localized depend on your browser's language settings.

## Backward compatibility
This change is fully backward compatible.

## Previously approved PR:
https://github.com/Fliplet/fliplet-widget-notification-inbox/pull/36
Fixed date format to notification

## Reviewers
@upplabs-alex-levchenko