### PR TITLE
ID-2444 [Fix] Only show "no notifications found" if there's messages at all

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -287,7 +287,7 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function(element, data) {
 
   function attachObservers() {
     if (data.mode !== 'demo' || !Fliplet.App.isPreview(true)) {
-      Fliplet.Hooks.on('notificationFirstResponse', function(err, notifications) {
+      Fliplet.Hooks.on('notificationFirstResponse', function(err, messages) {
         if (err) {
           $('.notifications').html(Fliplet.Widget.Templates['templates.notificationsError']());
           Fliplet.UI.Toast.error(err, {
@@ -297,9 +297,10 @@ Fliplet.Registry.set('notification-inbox:1.0:core', function(element, data) {
           return;
         }
 
-        if (!_.filter(notifications, function(notification) {
-          return !notification.deletedAt && notification.status !== 'draft';
-        }).length) {
+        // Show "No notifications found" UI if there's no new or existing notifications
+        if (!_.filter(messages, function(message) {
+          return !message.deletedAt && message.status !== 'draft';
+        }).length && !notifications.length) {
           noNotificationsFound();
         }
       });


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-2444

When used in offline mode, the "No notifications found" UI was being shown when there's no new notifications loaded, but did not consider notifications would have been loaded from cache already.

This PR updates the inbox to check if there are existing notifications loaded from the cache as well.