### PR TITLE
ID-3525 [Fix] Prevent notification inbox from repeatedly checking for notification updates

### DIFF
--- a/js/app/libs.js
+++ b/js/app/libs.js
@@ -279,12 +279,6 @@ Fliplet.Registry.set('notification-inbox:1.0:app:core', function(data) {
       return handlePushNotificationPayload(data);
     });
 
-    // Check the latest notification count against badge when the app resumes into foreground
-    document.addEventListener('resume', function() {
-      // Wait for connection to return
-      setTimeout(checkForUpdatesSinceLastClear, 0);
-    }, false);
-
     // Check for updates when device comes back online
     Fliplet.Navigator.onOnline(checkForUpdatesSinceLastClear);
   }


### PR DESCRIPTION
Feature removed due to Cordova bug where resume event is repeatedly fired. Users can still reload the notification screen to update the badge count.

Ref. https://weboo.atlassian.net/browse/ID-3525