### PR TITLE
[HOTFIX] Add lodash as an explicit dependency

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -10,7 +10,8 @@
   "interface": {
     "dependencies": [
       "fliplet-core",
-      "fliplet-studio-ui"
+      "fliplet-studio-ui",
+      "lodash"
     ],
     "assets": [
       "css/interface.css",
@@ -22,7 +23,8 @@
       "jquery",
       "bootstrap",
       "fliplet-session",
-      "fliplet-notifications"
+      "fliplet-notifications",
+      "lodash"
     ],
     "appAssets": [
       "js/app/libs.js",


### PR DESCRIPTION
## Summary
- Add `lodash` as an explicit dependency in both `interface.dependencies` and runtime dependencies in `widget.json`
- Prevents runtime/interface failures caused by relying on lodash being transitively available

## Test plan
- [ ] Verify the widget loads in Studio without missing dependency errors
- [ ] Verify the widget runs in the app/viewer with lodash available
- [ ] Confirm no regressions in notification inbox rendering or interactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)